### PR TITLE
docs: add Explore and Publish guides for v5.0.12

### DIFF
--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -20,6 +20,7 @@
   icon_color: blue
   pages:
     - title: Overview
+    - title: Explore
     - title: Export
     - title: Import
     - title: Remove
@@ -35,6 +36,7 @@
     - title: Schedule
     - title: Loop
     - title: Monitor
+    - title: Publish
 
 - title: Step
   icon: braces-asterisk

--- a/site/src/content/docs/automation/overview.mdx
+++ b/site/src/content/docs/automation/overview.mdx
@@ -15,7 +15,7 @@ sections:
     description: Re-run matching steps when new content is added on dynamic pages.
   - title: Publish
     description: Publish automation metadata to the cloud so other users can discover and import it.
-  - title: Automation Settings
+  - title: Settings
     description: Adjust automation-level settings such as run mode, URL matching, and page load timing.
   - title: Schedule
     description: Schedule an automation to run on a specific date and time, with an optional repeat interval.

--- a/site/src/content/docs/automation/overview.mdx
+++ b/site/src/content/docs/automation/overview.mdx
@@ -13,6 +13,8 @@ sections:
     description: Repeat the full automation or refresh the page after all steps complete.
   - title: Monitor
     description: Re-run matching steps when new content is added on dynamic pages.
+  - title: Publish
+    description: Publish automation metadata to the cloud so other users can discover and import it.
   - title: Automation Settings
     description: Adjust automation-level settings such as run mode, URL matching, and page load timing.
   - title: Schedule
@@ -27,7 +29,7 @@ sections:
   alt=""
 />
 
-An automation is the top-level unit. Each automation targets a URL, contains one or more [Steps]([[docsref:/step/overview]]), and can optionally define [Loop]([[docsref:/automation/loop]]), [Monitor]([[docsref:/automation/monitor]]), and [Automation Settings]([[docsref:/automation/settings]]).
+An automation is the top-level unit. Each automation targets a URL, contains one or more [Steps]([[docsref:/step/overview]]), and can optionally define [Loop]([[docsref:/automation/loop]]), [Monitor]([[docsref:/automation/monitor]]), [Publish]([[docsref:/automation/publish]]), and [Automation Settings]([[docsref:/automation/settings]]).
 
 ## Name and Actions
 
@@ -64,6 +66,7 @@ Click the split button next to the name to open a menu with all automation actio
 | **Schedule**  | Open [Schedule]([[docsref:/automation/schedule]]) settings to configure when the automation should run automatically. |
 | **Loop**      | Open [Loop]([[docsref:/automation/loop]]) settings to set repeat count and interval.                                  |
 | **Monitor**   | Open [Monitor]([[docsref:/automation/monitor]]) settings to watch for page changes.                                   |
+| **Publish**   | Open [Publish]([[docsref:/automation/publish]]) to publish, unpublish, or clone cloud-published automations.          |
 | **Duplicate** | Create a copy of the automation and add it to the list.                                                               |
 | **Disable**   | Temporarily turn off the automation without deleting it.                                                              |
 | **Remove**    | Permanently delete the automation.                                                                                    |

--- a/site/src/content/docs/automation/publish.mdx
+++ b/site/src/content/docs/automation/publish.mdx
@@ -1,0 +1,51 @@
+---
+title: Publish
+description: Publish automations to the cloud, manage metadata, unpublish your own entries, and duplicate automations published by others.
+tags: [automation, publish, unpublish, metadata, cloud]
+toc: true
+aliases:
+  - '/docs/automation/publish/'
+  - '/automation/publish/'
+---
+
+Use Publish to share an automation with the community feed and manage how it appears in Explore.
+
+## Open Publish
+
+1. Open an automation.
+2. Click the split action menu next to the automation name.
+3. Select **Publish**.
+
+## Metadata fields
+
+When publishing, you can set:
+
+- **Title** (required, up to 100 characters)
+- **Description** (optional, up to 500 characters)
+- **Tags** (optional, comma-separated, up to 100 characters total)
+
+A URL-friendly slug is generated automatically from the title.
+
+## Ownership and permissions
+
+- You can publish a new automation when logged in.
+- You can update or unpublish only automations you published.
+- If an automation is already published by another user, you cannot overwrite it.
+
+In that case, use **Duplicate** first, then publish your own copy.
+
+## Unpublish
+
+If you are the owner of a published automation, Publish shows an **Unpublish** action.
+
+- Unpublish removes the cloud metadata entry.
+- Your local automation stays in your list.
+
+## Visual status in list
+
+Published automations show a cloud icon in the automations list so you can quickly identify which entries are synced to the public feed.
+
+## Related pages
+
+- Browse and import shared automations in [Explore]([[docsref:/automations/explore]]).
+- Export local JSON backups from [Export Automations]([[docsref:/automations/export]]).

--- a/site/src/content/docs/automations/explore.mdx
+++ b/site/src/content/docs/automations/explore.mdx
@@ -13,7 +13,7 @@ Use Explore to browse community-published automations and import them into your 
 ## Before you start
 
 - You must be logged in to browse and import published automations.
-- Imports are added to your current list, they do not replace existing automations.
+- Imports are added to your current list; they do not replace existing automations.
 
 ## What you can do in Explore
 

--- a/site/src/content/docs/automations/explore.mdx
+++ b/site/src/content/docs/automations/explore.mdx
@@ -1,0 +1,54 @@
+---
+title: Explore
+description: Discover public automations, filter results, and import published automations into your list.
+tags: [explore, automations, publish, import, community]
+toc: true
+aliases:
+  - '/docs/automations/explore/'
+  - '/automations/explore/'
+---
+
+Use Explore to browse community-published automations and import them into your own list.
+
+## Before you start
+
+- You must be logged in to browse and import published automations.
+- Imports are added to your current list, they do not replace existing automations.
+
+## What you can do in Explore
+
+<BsTable>
+
+| **Feature**            | **Description**                                                  |
+| ---------------------- | ---------------------------------------------------------------- |
+| **Search**             | Search by title, URL, or related keywords.                       |
+| **Tags toggle**        | Show or hide tag badges in list results.                         |
+| **Description toggle** | Show or hide description text to make the list more compact.     |
+| **Load More**          | Fetch the next page of published automations.                    |
+| **Import**             | Download and import a selected automation into your account.     |
+| **Download count**     | View how many times each published automation has been imported. |
+
+</BsTable>
+
+## Search behavior
+
+- Search is debounced to reduce repeated requests while you type.
+- Results refresh when the search box is cleared or when the query has at least 3 characters.
+
+## Import flow
+
+1. Open **Explore** from the left sidebar.
+2. Find an automation and click the cloud download icon.
+3. Confirm the import prompt.
+4. The extension imports the automation and opens it immediately for editing.
+
+<Callout type="info">
+  Imported automations may include newer fields. The extension migrates imported data to your current format
+  automatically.
+</Callout>
+
+## Tips
+
+- Start with broad terms, then narrow with longer keywords.
+- Keep description view enabled when comparing similar automations.
+- Check the URL and author name before importing.

--- a/site/src/content/docs/automations/overview.mdx
+++ b/site/src/content/docs/automations/overview.mdx
@@ -1,11 +1,13 @@
 ---
 title: Automations
-description: Browse, search, import, reorder, and manage all saved automations in one place.
+description: Browse, search, explore, import, reorder, and manage all saved automations in one place.
 toc: true
 tags: [automations, list, configuration-list]
 aliases:
   - '/docs/4.x/config-list/overview/'
 sections:
+  - title: Explore
+    description: Discover public automations shared by other users and import them into your list.
   - title: Export
     description: Select one or more automations and export them to a JSON file for backup or transfer.
   - title: Import
@@ -29,6 +31,7 @@ sections:
 | **Feature**      | **Description**                                                                 |
 | ---------------- | ------------------------------------------------------------------------------- |
 | **New**          | Create a new automation from the top-right‑click button.                        |
+| **Explore**      | Discover public automations and import them from the community feed.            |
 | **Import**       | Import one or more automations from a JSON export.                              |
 | **Search**       | Filter automations by name or URL.                                              |
 | **Select**       | Enter bulk-selection mode to export or delete multiple automations.             |
@@ -40,11 +43,12 @@ sections:
 
 ## Typical workflow
 
-1. Review the automation list to find an existing entry or create a new one.
+1. Review your automation list to find an existing entry or create a new one.
 2. Use the search box to filter by automation name or target URL.
-3. Click an automation to open its detail screen and edit its steps.
-4. Use `Select` when you want to bulk export or bulk remove multiple items.
-5. Use `Reorder` to control which automation wins when several match the same page.
+3. Use [Explore]([[docsref:/automations/explore]]) when you want to import public automations.
+4. Click an automation to open its detail screen and edit its steps.
+5. Use `Select` when you want to bulk export or bulk remove multiple items.
+6. Use `Reorder` to control which automation wins when several match the same page.
 
 ## Best practices
 


### PR DESCRIPTION
## Summary
- add a new Explore documentation page for browsing and importing published automations
- add a new Publish documentation page for automation sharing ownership and unpublish behavior
- update sidebar navigation and overview docs to include Explore and Publish entries

## Context
- aligned with automation publish/explore changes from PR #822

## Validation
- formatted changed docs files with project Prettier config
- verified changed docs files pass Prettier check