### PR TITLE
feat: Update deployment workflow to trigger on version tags and add r…

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "acf-docs-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "docs-serve"],
+      "port": 9001
+    }
+  ]
+}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,7 +2,7 @@ name: Deploy [Docs]
 
 on:
   push:
-    branches: ["main"]
+    tags: ["v*"]
   workflow_dispatch:
 
 env:
@@ -10,10 +10,10 @@ env:
   NODE: 24
 
 jobs:
-  docs:
+  build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Clone repository
@@ -48,14 +48,12 @@ jobs:
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
-        if: github.ref == 'refs/heads/main'
         with:
           path: ./_site
 
   deploy:
     runs-on: ubuntu-latest
-    needs: docs
-    if: github.ref == 'refs/heads/main'
+    needs: build
     permissions:
       pages: write
       id-token: write
@@ -68,3 +66,22 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+
+  release:
+    name: Create Release
+    needs: deploy
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Release to GitHub
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
+        id: release
+        with:
+          generate_release_notes: true

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,7 +30,7 @@ jobs:
       - run: java -version
 
       - name: Install npm dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build docs
         run: npm run docs-build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Test
+
+on:
+  pull_request:
+
+env:
+  FORCE_COLOR: 2
+  NODE: 24
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: '${{ env.NODE }}'
+          cache: 'npm'
+
+      - run: java -version
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build docs
+        run: npm run docs-build
+
+      - name: Validate HTML
+        run: npm run docs-vnu
+
+      - name: Run linkinator
+        uses: JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d # v1.11.0
+        with:
+          paths: _site
+          recurse: true
+          verbosity: error
+          skip: '^http://localhost'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - run: java -version
 
       - name: Install npm dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build docs
         run: npm run docs-build

--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -1,3 +1,4 @@
+import { unified } from '@astrojs/markdown-remark'
 import { defineConfig } from 'astro/config'
 
 import { bootstrap } from './src/libs/astro'
@@ -20,7 +21,7 @@ export default defineConfig({
   },
   integrations: [bootstrap()],
   markdown: {
-    smartypants: false,
+    processor: unified({ smartypants: false }),
     syntaxHighlight: 'prism'
   },
   site,

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -14,6 +14,7 @@
   pages:
     - title: Overview
     - title: Recording
+    - title: Ask AI
 
 - title: Automations
   icon: ui-radios

--- a/site/src/components/footer/Footer.astro
+++ b/site/src/components/footer/Footer.astro
@@ -42,7 +42,7 @@ import { getVersionedDocsPath } from '@libs/path'
           <li class="mb-2"><a href={getVersionedDocsPath('automation/loop')}>Loop</a></li>
           <li class="mb-2"><a href={getVersionedDocsPath('step/overview')}>Step</a></li>
           <li class="mb-2"><a href={getVersionedDocsPath('settings/overview')}>Settings</a></li>
-          <li class="mb-2"><a href={getVersionedDocsPath('addon/overview')}>Addon</a></li>
+          <li class="mb-2"><a href={getVersionedDocsPath('step/page-guard')}>Page Guard</a></li>
         </ul>
       </div>
       <div class="col-6 col-lg-2 mb-3">

--- a/site/src/components/header/Navigation.astro
+++ b/site/src/components/header/Navigation.astro
@@ -84,7 +84,6 @@ const { addedIn, layout, title } = Astro.props
           <LinkItem active={layout === 'docs'} href={getVersionedDocsPath('getting-started/introduction/')} track>
             Docs
           </LinkItem>
-          <LinkItem active={title === 'Examples'} href={getVersionedDocsPath('examples/')} track>Examples</LinkItem>
           <LinkItem href={getConfig().discussion} target="_blank" rel="noopener" track>Discussion</LinkItem>
           <LinkItem href={getConfig().test} target="_blank" rel="noopener" track>Test</LinkItem>
         </ul>

--- a/site/src/components/shortcodes/SubscriptionBadge.astro
+++ b/site/src/components/shortcodes/SubscriptionBadge.astro
@@ -1,0 +1,19 @@
+---
+/*
+ * Outputs a badge linking to the upgrade plan page, for PLUS/PRO-gated features
+ */
+import { getVersionedDocsPath } from '@libs/path'
+
+interface Props {
+  plan: 'PLUS' | 'PRO'
+}
+
+const { plan } = Astro.props
+---
+
+<a
+  href={getVersionedDocsPath('about/upgrade-plan')}
+  class={`d-inline-flex text-decoration-none px-2 py-1 fs-6 fw-semibold bg-${plan === 'PRO' ? 'pro' : 'plus'} rounded-2`}
+>
+  {plan}
+</a>

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -25,6 +25,7 @@ const docsSchema = z.object({
     })
     .array()
     .optional(),
+  subscription: z.enum(['PLUS', 'PRO']).optional(),
   thumbnail: z.string().optional(),
   title: z.string(),
   toc: z.boolean().optional()

--- a/site/src/content/docs/about/upgrade-plan.mdx
+++ b/site/src/content/docs/about/upgrade-plan.mdx
@@ -1,7 +1,7 @@
 ---
 title: Upgrade Plan
-description: Unlock advanced features with PLUS or PRO plans
-tags: [subscription, upgrade, plus, pro, pro-features]
+description: PLUS and PRO unlock advanced features. Each plan includes a one-time 14-day free trial — there is no other free or limited usage of PLUS/PRO features.
+tags: [subscription, upgrade, plus, pro, pro-features, trial, free-trial]
 toc: true
 aliases:
   - '/docs/4.x/about/subscription/'
@@ -11,9 +11,17 @@ aliases:
 
 Unlock advanced features and get the most out of Auto Clicker AutoFill by upgrading your plan.
 
+## Free Trial
+
+Every account gets a one-time **14-day free trial** for PLUS, and a separate one-time 14-day free trial for PRO. Start a trial from the **Subscription** section of the extension's options page.
+
+- Each trial runs once per account, per plan. Once it ends, that plan's features require an active paid subscription to keep using them.
+- There is no other free or limited access to PLUS or PRO features — the trial is the only way to use them without subscribing.
+- The FREE tier below always remains free, with no trial or subscription required.
+
 ## 🆓 FREE
 
-Powerful automation for everyone — no account required.
+Powerful automation for everyone — no account, trial, or subscription required.
 
 **What's included:**
 
@@ -25,24 +33,27 @@ Powerful automation for everyone — no account required.
 
 ## 🚀 PLUS
 
-All the essentials, plus deeper control over pre-check and settings within steps.
+Everything in Free, plus deeper control over automation timing and step conditions.
 
 **Everything in Free, plus:**
 
-- Conditional addon logic
-- Per-action condition rules
-- Action-level settings & overrides
-- Ad-free experience
+- 🚫 Ad-free experience
+- [Loop]([[docsref:/automation/loop]]) — repeat an entire automation
+- [Monitor]([[docsref:/automation/monitor]]) — watch for page changes and re-run matching steps
+- [Schedule]([[docsref:/automation/schedule]]) — run automations on a schedule
+- [Page Guard]([[docsref:/step/page-guard]]) — gate a step on a page condition before it runs
+- [State Guard]([[docsref:/step/state-guard]]) — conditional checks between steps
+- [Step Settings]([[docsref:/step/step-settings]]) — step-level retry and error-handling overrides
 
 ## 🔹 PRO
 
-The full power of automation — with integrations, AI, and priority support.
+Everything in Plus, plus integrations, AI, and priority support.
 
 **Everything in Plus, plus:**
 
-- Google Sheets integration
+- [Google Sheets integration]([[docsref:/step-value/google-sheets]])
 - Discord notifications
-- Captcha resolver (coming soon)
+- [Captcha solver]([[docsref:/step-value/captcha]])
+- [AI / OpenAI integration]([[docsref:/step-value/ai]])
 - Priority support via Discord
-- Early access to new features
-- Supporter badge & community recognition
+- Gmail integration *(coming soon)*

--- a/site/src/content/docs/automation/loop.mdx
+++ b/site/src/content/docs/automation/loop.mdx
@@ -2,6 +2,7 @@
 title: Loop
 description: Configure how many times an automation repeats, the interval between loops, and whether to refresh the page after completion.
 tags: [loop, batch, automation, configuration, repeat, refresh, repeat-interval]
+subscription: PLUS
 toc: true
 aliases:
   - '/docs/4.x/automation/batch/'
@@ -12,11 +13,6 @@ aliases:
 ---
 
 <img class="d-block mb-4 img-fluid rounded-3 border" src="/docs/[[config:docs_version]]/assets/img/loop.png" alt="" />
-
-<Callout type="warning">
-  Loop **Repeat** (including unlimited) requires a [PLUS plan]([[docsref:/about/upgrade-plan]]). For FREE users the
-  automation runs once and a subscription notice is shown.
-</Callout>
 
 <ExampleAutomation file="loop" plus>Watch `<loopRepeat>` count up on each batch.</ExampleAutomation>
 

--- a/site/src/content/docs/automation/monitor.mdx
+++ b/site/src/content/docs/automation/monitor.mdx
@@ -2,6 +2,7 @@
 title: Monitor
 description: Enable monitoring so matching steps can re-run when new content appears on dynamic pages.
 tags: [monitor, watch, debounce, watch-root-selector, timeout, stop-on-url-change]
+subscription: PLUS
 toc: true
 added:
   version: '4.1.0'

--- a/site/src/content/docs/automation/publish.mdx
+++ b/site/src/content/docs/automation/publish.mdx
@@ -3,6 +3,8 @@ title: Publish
 description: Publish automations to the cloud, manage metadata, unpublish your own entries, and duplicate automations published by others.
 tags: [automation, publish, unpublish, metadata, cloud]
 toc: true
+added:
+  version: '5.0.12'
 aliases:
   - '/docs/automation/publish/'
   - '/automation/publish/'

--- a/site/src/content/docs/automation/schedule.mdx
+++ b/site/src/content/docs/automation/schedule.mdx
@@ -2,6 +2,9 @@
 title: Schedule
 description: Schedule an automation to run automatically on a specific date and time, with an optional repeat interval in minutes.
 toc: true
+added:
+  version: '5.0.0'
+subscription: PLUS
 tags: [schedule, automation, date, time, repeat, alarm, timer, scheduled-run]
 ---
 

--- a/site/src/content/docs/automation/settings.mdx
+++ b/site/src/content/docs/automation/settings.mdx
@@ -127,7 +127,7 @@ Set the hotkey used by Manual mode. Supported combinations include:
 
 See [Run Mode]([[docsref:/automation/settings#run-mode]]).
 
-## Google Sheets ID
+## Google Sheets ID <SubscriptionBadge plan="PRO" />
 
 Use this when your automation reads or writes values through Google Sheets features.
 

--- a/site/src/content/docs/automations/explore.mdx
+++ b/site/src/content/docs/automations/explore.mdx
@@ -3,6 +3,8 @@ title: Explore
 description: Discover public automations, filter results, and import published automations into your list.
 tags: [explore, automations, publish, import, community]
 toc: true
+added:
+  version: '5.0.12'
 aliases:
   - '/docs/automations/explore/'
   - '/automations/explore/'

--- a/site/src/content/docs/automations/reorder.mdx
+++ b/site/src/content/docs/automations/reorder.mdx
@@ -3,6 +3,8 @@ title: Reorder Automations
 description: Change the order of automations to control which one runs first when multiple items match.
 tags: [reorder, automations, configuration-list]
 toc: true
+added:
+  version: '3.1.9'
 aliases:
   - '/docs/3.x/configuration-list/reorder-configurations/'
   - '/docs/4.x/config-list/reorder/'

--- a/site/src/content/docs/extension/log.mdx
+++ b/site/src/content/docs/extension/log.mdx
@@ -3,6 +3,8 @@ title: Log
 description: Track extension execution with an improved, structured logging view
 tags: [extension, logging, debugging]
 toc: true
+added:
+  version: '3.1.5'
 aliases:
   - '/docs/3.x/extension/log/'
   - '/docs/4.x/extension/log/'

--- a/site/src/content/docs/extension/status-bar.mdx
+++ b/site/src/content/docs/extension/status-bar.mdx
@@ -3,6 +3,8 @@ title: Status Bar
 description: Track automation and execution status from the in-page status bar and Chrome Action badge
 tags: [status-bar, configuration, execution, ui]
 toc: true
+added:
+  version: '3.1.5'
 aliases:
   - '/docs/4.x/extension/status-bar/'
   - '/docs/4.x/extension/icon/'

--- a/site/src/content/docs/extension/theme.mdx
+++ b/site/src/content/docs/extension/theme.mdx
@@ -3,6 +3,8 @@ title: Theme
 description: Customize the extension’s appearance with Light and Dark themes
 tags: [theme, extension, ui]
 toc: true
+added:
+  version: '3.2.4'
 aliases:
   - '/docs/4.x/extension/theme/'
 ---

--- a/site/src/content/docs/settings/additional-settings.mdx
+++ b/site/src/content/docs/settings/additional-settings.mdx
@@ -3,6 +3,8 @@ title: Settings · Additional Settings
 description: Configure embedded page search, automatic page reload on error, and status bar position.
 tags: [settings, additional-settings, check-iframes, reload-on-error, status-bar]
 toc: true
+added:
+  version: '5.0.5'
 aliases:
   - '/docs/4.x/settings/status-bar-location/'
 ---

--- a/site/src/content/docs/settings/cloud-backup.mdx
+++ b/site/src/content/docs/settings/cloud-backup.mdx
@@ -3,6 +3,8 @@ title: Settings · Cloud Backup
 description: Back up and restore your automations to Google Drive (App Data folder)
 tags: [settings, cloud-backup, backup, google-drive, backup-daily, backup-weekly, backup-monthly, backup-off, restore]
 toc: true
+added:
+  version: '5.0.5'
 aliases:
   - '/docs/4.x/settings/backup/'
 ---

--- a/site/src/content/docs/settings/google-sheets.mdx
+++ b/site/src/content/docs/settings/google-sheets.mdx
@@ -2,6 +2,7 @@
 title: Settings · Google Sheets
 description: Extension can fetch the values from your Google Sheets and fill the forms on behalf of you.
 tags: [settings, google-sheets, automation, google-sheets-login, pro]
+subscription: PRO
 toc: true
 aliases:
   - '/docs/4.x/settings/google-sheets/'

--- a/site/src/content/docs/settings/migration-backup.mdx
+++ b/site/src/content/docs/settings/migration-backup.mdx
@@ -3,6 +3,8 @@ title: Settings · Migration Backup
 description: View, download, or restore local snapshots captured automatically before schema migrations.
 tags: [settings, migration-backup, backup, restore]
 toc: true
+added:
+  version: '5.0.5'
 ---
 
 <img

--- a/site/src/content/docs/settings/show-notification.mdx
+++ b/site/src/content/docs/settings/show-notification.mdx
@@ -3,6 +3,8 @@ title: Settings · Show Notification
 description: Control how the extension displays notifications and optionally send alerts via Discord
 tags: [settings, notifications, discord, global-settings]
 toc: true
+added:
+  version: '3.3.0'
 aliases:
   - '/docs/4.x/settings/show-notification/'
 ---
@@ -28,7 +30,7 @@ aliases:
 
 Toggle whether notifications play a sound.
 
-## Notification on Discord
+## Notification on Discord <SubscriptionBadge plan="PRO" />
 
 Connect the extension to a Discord server to receive notifications there. When enabled:
 

--- a/site/src/content/docs/side-panel/ask-ai.mdx
+++ b/site/src/content/docs/side-panel/ask-ai.mdx
@@ -1,0 +1,36 @@
+---
+title: Ask AI
+description: Ask questions about Auto Clicker Auto Fill from the Side Panel and get instant, sourced answers powered by AI.
+tags: [ask-ai, chat, side-panel, openai, qna]
+toc: true
+added:
+  version: '5.0.0'
+---
+
+Ask AI is a chat-style Q&A assistant built into the Side Panel. Ask a question in plain language and get a sourced answer without leaving the page you're on.
+
+<Callout type="info">
+  Ask AI is free for everyone. It isn't part of Plus or Pro, and it has no usage limit — you only need to be signed in.
+</Callout>
+
+## How To Open
+
+Use any of the following:
+
+1. Open the Side Panel and select the `Ask` tab.
+2. Right-click on a page and choose <kbd>✨ Ask AI</kbd> — this opens the Side Panel directly on the `Ask` tab.
+3. From the extension's Configuration page, click the floating <kbd>🤖</kbd> button in the bottom-right corner.
+
+## Asking A Question
+
+1. If you're not signed in yet, click `Sign In` — this is the same sign-in used elsewhere in the extension.
+2. Type your question, e.g. `What is a loop?`, and click `Send`.
+3. The answer renders as formatted text. When the answer draws on specific documentation pages, a `Sources` list of links appears underneath it.
+
+Each exchange stays in the tab's history until the Side Panel is closed, so you can ask follow-up questions in the same session.
+
+## Rating An Answer
+
+Every answer has 👍 / 👎 buttons. Rating is optional and only used to improve future answers — it doesn't change the answer you already received.
+
+See [Side Panel]([[docsref:/side-panel/overview]]) for the other Side Panel tabs and opening methods.

--- a/site/src/content/docs/side-panel/overview.mdx
+++ b/site/src/content/docs/side-panel/overview.mdx
@@ -28,10 +28,11 @@ Once opened, the panel stays attached to the browser side and updates as you nav
 
 ## Tabs Overview
 
-The Side Panel has two tabs:
+The Side Panel has three tabs:
 
 1. `Automations`
 2. `Recording`
+3. `Ask`
 
 ### Automations Tab
 
@@ -49,6 +50,13 @@ The Side Panel has two tabs:
 - Use `Stop Recording` to end capture.
 
 For detailed recording behavior, see [Recording]([[docsref:/side-panel/recording]]).
+
+### Ask Tab
+
+- Ask a question in plain language and get a sourced, AI-generated answer.
+- Free for everyone, with no usage limit — sign-in is the only requirement.
+
+For detailed usage, see [Ask AI]([[docsref:/side-panel/ask-ai]]).
 
 ## Footer Links
 

--- a/site/src/content/docs/side-panel/recording.mdx
+++ b/site/src/content/docs/side-panel/recording.mdx
@@ -3,6 +3,8 @@ title: Recording
 description: Start recording from the Side Panel and capture steps live while you interact with the page.
 tags: [recording, automation, side-panel]
 toc: true
+added:
+  version: '3.4.3'
 aliases:
   - '/docs/3.x/record/overview/'
   - '/docs/4.x/record/overview/'

--- a/site/src/content/docs/step-value/ai.mdx
+++ b/site/src/content/docs/step-value/ai.mdx
@@ -2,6 +2,7 @@
 title: AI
 description: Generate AI-powered content using a configured provider such as OpenAI.
 tags: [step, value, ai, step-value]
+subscription: PRO
 toc: true
 aliases:
   - '/docs/4.x/action-value/ai/'

--- a/site/src/content/docs/step-value/attribute.mdx
+++ b/site/src/content/docs/step-value/attribute.mdx
@@ -3,6 +3,8 @@ title: Attribute
 description: Update the attribute of the element using below commands.
 tags: [action, value, attribute, action-value]
 toc: true
+added:
+  version: '3.3.0'
 aliases:
   - '/docs/4.x/action-value/attribute/'
 ---

--- a/site/src/content/docs/step-value/captcha.mdx
+++ b/site/src/content/docs/step-value/captcha.mdx
@@ -1,7 +1,8 @@
 ---
-title: Captcha [PRO Feature]
+title: Captcha
 description: Resolve image captcha using AI
 tags: [action, value, captcha, action-value]
+subscription: PRO
 toc: true
 aliases:
   - '/docs/4.x/action-value/captcha/'

--- a/site/src/content/docs/step-value/class.mdx
+++ b/site/src/content/docs/step-value/class.mdx
@@ -3,6 +3,8 @@ title: Class
 description: Update the class attribute of and element selected using element finder
 tags: [action, value, class, action-value]
 toc: true
+added:
+  version: '3.3.0'
 aliases:
   - '/docs/4.x/action-value/class/'
 ---

--- a/site/src/content/docs/step-value/clipboard.mdx
+++ b/site/src/content/docs/step-value/clipboard.mdx
@@ -3,6 +3,8 @@ title: Clipboard
 description: Now you can copy any content from webpage using copy command and paste back any where within clipboard.
 tags: [action, value, clipboard, action-value]
 toc: true
+added:
+  version: '2.0.60'
 aliases:
   - '/docs/4.x/action-value/clipboard/'
 ---

--- a/site/src/content/docs/step-value/copy.mdx
+++ b/site/src/content/docs/step-value/copy.mdx
@@ -3,6 +3,8 @@ title: Copy
 description: Copy text content or a regex-extracted value from a page element for use in subsequent steps.
 tags: [action, value, copy, action-value]
 toc: true
+added:
+  version: '3.4.3'
 aliases:
   - '/docs/4.x/action-value/copy/'
 ---

--- a/site/src/content/docs/step-value/form-events.mdx
+++ b/site/src/content/docs/step-value/form-events.mdx
@@ -3,6 +3,8 @@ title: Form Events
 description: Perform form specific events on input field and button of form.
 tags: [action, value, form, action-value]
 toc: true
+added:
+  version: '2.0.60'
 aliases:
   - '/docs/4.x/action-value/form-events/'
 ---

--- a/site/src/content/docs/step-value/google-sheets.mdx
+++ b/site/src/content/docs/step-value/google-sheets.mdx
@@ -2,6 +2,7 @@
 title: Google Sheets
 description: Connect with your google account and fill form using google sheets data directly in iterative manner.
 tags: [action, value, google-sheets, action-value]
+subscription: PRO
 toc: true
 aliases:
   - '/docs/4.x/action-value/google-sheets/'

--- a/site/src/content/docs/step-value/location-command.mdx
+++ b/site/src/content/docs/step-value/location-command.mdx
@@ -3,6 +3,8 @@ title: Location Command
 description: Perform location specific commands
 tags: [action, value, location, action-value]
 toc: true
+added:
+  version: '3.1.0'
 aliases:
   - '/docs/4.x/action-value/location-command/'
 ---

--- a/site/src/content/docs/step-value/mouse-events.mdx
+++ b/site/src/content/docs/step-value/mouse-events.mdx
@@ -3,6 +3,8 @@ title: Mouse Events
 description: Perform click events and mouse events using below commands
 tags: [action, value, mouse, action-value]
 toc: true
+added:
+  version: '2.0.60'
 aliases:
   - '/docs/4.x/action-value/mouse-events/'
 ---

--- a/site/src/content/docs/step-value/paste.mdx
+++ b/site/src/content/docs/step-value/paste.mdx
@@ -3,6 +3,8 @@ title: Paste
 description: Now you can paste content into input fields which are copied by extension using [copy]([[docsref:/step-value/copy/]]) command within same domain.
 tags: [action, value, paste, action-value]
 toc: true
+added:
+  version: '3.4.3'
 aliases:
   - '/docs/4.x/action-value/paste/'
 ---

--- a/site/src/content/docs/step-value/query-param.mdx
+++ b/site/src/content/docs/step-value/query-param.mdx
@@ -3,6 +3,8 @@ title: Query Param
 description: Fetch values passed in url of web page and use same to fill the forms.
 tags: [action, value, query, action-value]
 toc: true
+added:
+  version: '3.2.0'
 aliases:
   - '/docs/4.x/action-value/query-param/'
 ---

--- a/site/src/content/docs/step-value/random-value.mdx
+++ b/site/src/content/docs/step-value/random-value.mdx
@@ -3,6 +3,8 @@ title: Random Value
 description: Now fill generate random value into form fields
 tags: [action, value, random, action-value]
 toc: true
+added:
+  version: '3.4.3'
 aliases:
   - '/docs/4.x/action-value/random-value/'
 ---

--- a/site/src/content/docs/step-value/scroll-to.mdx
+++ b/site/src/content/docs/step-value/scroll-to.mdx
@@ -3,6 +3,8 @@ title: Scroll To
 description: Scroll to any specific part of application or to specific element using below command
 tags: [action, value, scroll, action-value]
 toc: true
+added:
+  version: '2.0.60'
 aliases:
   - '/docs/4.x/action-value/scroll-to/'
 ---

--- a/site/src/content/docs/step-value/select-option.mdx
+++ b/site/src/content/docs/step-value/select-option.mdx
@@ -3,6 +3,8 @@ title: Select Option
 description: These commands are specific to dropdown
 tags: [action, value, select, action-value]
 toc: true
+added:
+  version: '3.1.13'
 aliases:
   - '/docs/4.x/action-value/select-option/'
 ---

--- a/site/src/content/docs/step/columns-filter.mdx
+++ b/site/src/content/docs/step/columns-filter.mdx
@@ -2,6 +2,8 @@
 title: Step · Columns Filter
 description: Show or hide optional columns in the Steps table to reduce clutter. This changes only the view, not behavior.
 toc: true
+added:
+  version: '2.0.57'
 tags: [step, action, columns, filter, visibility]
 aliases:
   - '/docs/4.x/action/columns-filter/'

--- a/site/src/content/docs/step/element-finder.mdx
+++ b/site/src/content/docs/step/element-finder.mdx
@@ -5,6 +5,8 @@ group: action
 tags:
   [step, action, element, finder, xpath, selectors, element-by-id, element-by-class, element-by-name, element-by-tag]
 toc: true
+added:
+  version: '3.1.0'
 aliases:
   - '/docs/4.x/action/element-finder/'
 ---

--- a/site/src/content/docs/step/page-guard.mdx
+++ b/site/src/content/docs/step/page-guard.mdx
@@ -2,6 +2,7 @@
 title: Page Guard
 description: Only run a step if a value on the page meets your condition — check text, attributes, or browser values before the step executes.
 toc: true
+subscription: PLUS
 tags: [page-guard, addon, condition, comparison, recheck, element-finder, value-extractor]
 aliases:
   - '/docs/3.x/addon/element-finder/'
@@ -25,11 +26,6 @@ aliases:
 />
 
 Only run this step if a value on the page meets your condition.
-
-<Callout type="warning">
-  Page Guard requires a [PLUS plan]([[docsref:/about/upgrade-plan]]). For FREE users the guard is skipped and the step
-  runs unconditionally.
-</Callout>
 
 <ExampleAutomation file="page-guard" plus>Watch guard conditions (Contains, GreaterThan, value extractor, recheck, `Func::`) gate each step.</ExampleAutomation>
 

--- a/site/src/content/docs/step/state-guard.mdx
+++ b/site/src/content/docs/step/state-guard.mdx
@@ -2,6 +2,7 @@
 title: State Guard
 description: Configure guard rules that test statuses of previous steps. If the guard matches, the current step runs; otherwise the selected fallback is applied.
 tags: [step, action, condition, status, action-condition]
+subscription: PLUS
 toc: true
 aliases:
   - '/docs/4.x/step/action-condition/'

--- a/site/src/content/docs/step/step-settings.mdx
+++ b/site/src/content/docs/step/step-settings.mdx
@@ -2,6 +2,7 @@
 title: Step Settings
 description: Overview of step settings including retry attempts, wait between retries, embedded page search, and fallback behavior.
 tags: [step, action, settings, retry, iframe, embedded, error-handling, action-settings]
+subscription: PLUS
 toc: true
 aliases:
   - '/docs/4.x/step/action-settings/'
@@ -13,10 +14,6 @@ aliases:
 ---
 
 These step-level settings override Global Settings and apply to both the step and its pre-checks. If you leave a field blank here, the step falls back to the global retry behavior.
-
-<Callout type="warning">
-  Step Settings require a [PLUS plan]([[docsref:/about/upgrade-plan]]).
-</Callout>
 
 <ExampleAutomation file="goto" plus>Step 1 fails to find its target and jumps straight to step 3.</ExampleAutomation>
 

--- a/site/src/content/docs/userscript/overview.mdx
+++ b/site/src/content/docs/userscript/overview.mdx
@@ -3,6 +3,8 @@ title: Userscript
 description: Author custom JavaScript that can run as a full step alongside other steps.
 tags: [userscript, javascript, automation]
 toc: true
+added:
+  version: '4.0.47'
 aliases:
   - '/docs/4.x/userscript/overview/'
 ---

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -8,6 +8,7 @@ import { getVersionedDocsPath } from '@libs/path'
 import Ads from '@components/Ads.astro'
 import BaseLayout from '@layouts/BaseLayout.astro'
 import DocsSidebar from '@components/DocsSidebar.astro'
+import SubscriptionBadge from '@shortcodes/SubscriptionBadge.astro'
 import TableOfContents from '@components/TableOfContents.astro'
 
 interface Props {
@@ -63,6 +64,11 @@ if (frontmatter.toc) {
                   </small>
                 )
             }
+            {frontmatter.subscription && (
+              <span class="me-2">
+                <SubscriptionBadge plan={frontmatter.subscription} />
+              </span>
+            )}
             <a
               class="btn btn-sm btn-bd-light rounded-2"
               href={`${getConfig().repo}/blob/v${getConfig().current_version}/site/src/content/docs/${id}`}

--- a/site/src/scss/docs.scss
+++ b/site/src/scss/docs.scss
@@ -57,3 +57,13 @@ $enable-cssgrid: true;
 // Load docs dependencies
 @import 'syntax';
 @import 'anchor';
+
+.bg-plus {
+  background: #feec41;
+  color: var(--bs-dark);
+}
+
+.bg-pro {
+  background: #e24b4a;
+  color: var(--bs-light);
+}

--- a/site/src/scss/docs.scss
+++ b/site/src/scss/docs.scss
@@ -61,6 +61,11 @@ $enable-cssgrid: true;
 .bg-plus {
   background: #feec41;
   color: var(--bs-dark);
+
+  &:hover,
+  &:focus {
+    color: var(--bs-dark);
+  }
 }
 
 .bg-pro {

--- a/site/src/types/auto-import.d.ts
+++ b/site/src/types/auto-import.d.ts
@@ -19,6 +19,7 @@ export declare global {
   export const JsDocs: typeof import('@shortcodes/JsDocs.astro').default
   export const Placeholder: typeof import('@shortcodes/Placeholder.astro').default
   export const ScssDocs: typeof import('@shortcodes/ScssDocs.astro').default
+  export const SubscriptionBadge: typeof import('@shortcodes/SubscriptionBadge.astro').default
   export const Table: typeof import('@shortcodes/Table.astro').default
   export const Video: typeof import('@shortcodes/Video.astro').default
 }


### PR DESCRIPTION
…elease step

- Change deployment trigger from main branch to version tags (v*)
- Update permissions for the build job to read-only
- Add a new release job that creates a GitHub release upon deployment
- Update sidebar to include new "Ask AI" section
- Extend content schema to include subscription plans
- Enhance upgrade plan documentation with free trial details
- Mark several automation features as PLUS or PRO subscription gated
- Add SubscriptionBadge component for subscription indicators
- Introduce Ask AI feature in the Side Panel for instant Q&A
- Update various documentation files with versioning and subscription requirements