### PR TITLE
fix(docs): repair all 19 broken internal links and fix the CI link gate

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -44,7 +44,7 @@ jobs:
           paths: _site
           recurse: true
           verbosity: error
-          skip: '^http://localhost'
+          skip: '^(?!http://localhost)'
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,4 +43,4 @@ jobs:
           paths: _site
           recurse: true
           verbosity: error
-          skip: '^http://localhost'
+          skip: '^(?!http://localhost)'

--- a/algolia/crawler.config.js
+++ b/algolia/crawler.config.js
@@ -1,6 +1,3 @@
-// The return value is intentionally unused. The Algolia crawler dashboard expects the
-// configuration as a bare `new Crawler({ ... })` expression, so it cannot be assigned or
-// exported. This file is a mirror of that dashboard config, not application code.
 new Crawler({ // NOSONAR
   appId: 'S4D9IW396R',
   // Crawler API key.

--- a/site/public/docs/5.x/assets/examples/copy-paste.json
+++ b/site/public/docs/5.x/assets/examples/copy-paste.json
@@ -1,0 +1,34 @@
+{
+  "id": "05e517f8-5ea9-4ad1-83f8-ce91e0945054",
+  "name": "Copy and Paste example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "fa69dacd-8377-4d08-b201-45225f0d9f8d",
+      "elementFinder": "#last-name",
+      "name": "Seed the source field",
+      "value": "Copy me 12345"
+    },
+    {
+      "id": "711febac-da1a-476a-82e1-186ea97ac83b",
+      "elementFinder": "#last-name",
+      "name": "Copy the field value",
+      "value": "Clipboard::copy::"
+    },
+    {
+      "id": "d855b8ab-e40b-454d-a76b-0e5333d7fbc8",
+      "elementFinder": "#address",
+      "name": "Paste it verbatim",
+      "value": "Clipboard::paste::"
+    },
+    {
+      "id": "c049624b-d370-4159-8b84-c0c14b33ba9b",
+      "elementFinder": "#inputEmail",
+      "name": "Paste transformed",
+      "value": "Clipboard::paste::toUpperCase()"
+    }
+  ]
+}

--- a/site/public/docs/5.x/assets/examples/element-finder.json
+++ b/site/public/docs/5.x/assets/examples/element-finder.json
@@ -1,0 +1,52 @@
+{
+  "id": "86132d8d-5e70-4038-b88a-2bc6618af436",
+  "name": "Element Finder example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "f2654a23-b4d5-4bc5-81da-1519d903f22e",
+      "elementFinder": "//input[@name=\"username\"]",
+      "name": "XPath by attribute",
+      "value": "xpath-attribute"
+    },
+    {
+      "id": "6fc067e2-eae6-4076-ba16-271d483e5444",
+      "elementFinder": "//input[contains(@placeholder,\"First name\")]",
+      "name": "XPath contains()",
+      "value": "xpath-contains"
+    },
+    {
+      "id": "9f4a60eb-ac4a-4518-a4fa-6b143da0a253",
+      "elementFinder": "#last-name",
+      "name": "ID with # prefix",
+      "value": "hash-id"
+    },
+    {
+      "id": "8c88d514-6b50-4a47-bb1b-4e3181b86058",
+      "elementFinder": "id::inputEmail",
+      "name": "ID with id:: prefix",
+      "value": "id-prefix@example.com"
+    },
+    {
+      "id": "091df324-d39a-42c3-8b12-22b9d74d4bd1",
+      "elementFinder": "Selector::#address",
+      "name": "CSS via Selector::",
+      "value": "css-selector"
+    },
+    {
+      "id": "0818f18b-0213-465a-a003-6003268d21c7",
+      "elementFinder": "Name::username",
+      "name": "By name attribute",
+      "value": "by-name"
+    },
+    {
+      "id": "90407f3c-7142-48f9-961d-11d482daa566",
+      "elementFinder": "#shadow-input",
+      "name": "Inside shadow DOM",
+      "value": "shadow-dom"
+    }
+  ]
+}

--- a/site/public/docs/5.x/assets/examples/events.json
+++ b/site/public/docs/5.x/assets/examples/events.json
@@ -1,0 +1,58 @@
+{
+  "id": "62f58dc6-7c10-455a-9588-7100fd758846",
+  "name": "Value commands showcase",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "2990b4c6-5b07-4596-8672-6fef76be6014",
+      "elementFinder": "#last-name",
+      "name": "Attr:: set an attribute",
+      "value": "Attr::set::data-example::hello"
+    },
+    {
+      "id": "bbe03a3a-0cb5-4cf3-954d-6031425ae0dd",
+      "elementFinder": "#address",
+      "name": "Class:: add a class",
+      "value": "Class::add::example-added"
+    },
+    {
+      "id": "5b13a73c-fd70-4c59-9301-47441aeb0e18",
+      "elementFinder": "#inputEmail",
+      "name": "Seed a value to transform",
+      "value": "cat@example.com"
+    },
+    {
+      "id": "52cad204-defa-46d0-ae5c-49dbcb23c26d",
+      "elementFinder": "#inputEmail",
+      "name": "Replace:: substring",
+      "value": "Replace::cat::dog"
+    },
+    {
+      "id": "d864d5fd-a87e-4431-8345-574dd35e3384",
+      "elementFinder": "#last-name",
+      "name": "Append:: to current value",
+      "value": "Append::-appended"
+    },
+    {
+      "id": "c3cc232f-4103-4bad-9dc4-f3c818f8f0f9",
+      "elementFinder": "#last-name",
+      "name": "Prepend:: to current value",
+      "value": "Prepend::pre-"
+    },
+    {
+      "id": "5211d5f8-73bb-4bdc-9644-8090e267c0d1",
+      "elementFinder": "#form-events-test",
+      "name": "FormEvents:: dispatch",
+      "value": "FormEvents::click"
+    },
+    {
+      "id": "c73ec4dc-ab54-4bab-8ea3-9db25a19c082",
+      "elementFinder": "#content-editable",
+      "name": "ScrollTo:: the page",
+      "value": "ScrollTo::Bottom"
+    }
+  ]
+}

--- a/site/public/docs/5.x/assets/examples/goto.json
+++ b/site/public/docs/5.x/assets/examples/goto.json
@@ -1,0 +1,34 @@
+{
+  "id": "95523be6-af71-475d-95fa-82bfb665bb77",
+  "name": "Goto example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "cd5d0cb2-3055-4fba-b470-a9acdce6589d",
+      "elementFinder": "#does-not-exist",
+      "name": "Step 1 - fails, jumps to step 3",
+      "value": "never runs",
+      "settings": {
+        "retry": 1,
+        "retryInterval": 1,
+        "retryOption": "goto",
+        "retryGoto": 2
+      }
+    },
+    {
+      "id": "f6a7d1a1-a083-4737-931c-445c73c70bb6",
+      "elementFinder": "#address",
+      "name": "Step 2 - jumped over",
+      "value": "skipped by the goto"
+    },
+    {
+      "id": "9103aa88-fd21-44ee-af35-74c8b3f17827",
+      "elementFinder": "#last-name",
+      "name": "Step 3 - the goto target",
+      "value": "jumped here from step 1"
+    }
+  ]
+}

--- a/site/public/docs/5.x/assets/examples/loop.json
+++ b/site/public/docs/5.x/assets/examples/loop.json
@@ -1,0 +1,24 @@
+{
+  "id": "44ce60aa-34ff-4251-bbef-fd1ac39b1d01",
+  "name": "Loop example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "batch": {
+    "repeat": 3,
+    "repeatInterval": 1
+  },
+  "actions": [
+    {
+      "id": "fdf5caeb-ee69-4f89-845d-06443e47f09e",
+      "elementFinder": "#last-name",
+      "value": "Loop run <loopRepeat>"
+    },
+    {
+      "id": "8444c59c-792e-43fa-aa9c-2f23c5c30ed9",
+      "elementFinder": "#inputEmail",
+      "value": "run-<loopRepeat>@example.com"
+    }
+  ]
+}

--- a/site/public/docs/5.x/assets/examples/page-guard.json
+++ b/site/public/docs/5.x/assets/examples/page-guard.json
@@ -1,0 +1,30 @@
+{
+  "id": "42a6de12-0d27-4727-aeb1-2a5c3d7d2299",
+  "name": "Page Guard example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "9fe3238f-9e9e-4ea8-83d1-2a251d852fd0",
+      "elementFinder": "#address",
+      "name": "Runs only if the guard matches",
+      "value": "Guard passed",
+      "addon": {
+        "elementFinder": "#last-name",
+        "value": "ready",
+        "condition": "Contains",
+        "recheck": 3,
+        "recheckInterval": 1,
+        "recheckOption": "skip"
+      }
+    },
+    {
+      "id": "a4e9cc3d-011a-4763-b38e-770f715ed4ca",
+      "elementFinder": "#last-name",
+      "name": "Sets the value the guard waits for",
+      "value": "ready"
+    }
+  ]
+}

--- a/site/public/docs/5.x/assets/examples/query-param.json
+++ b/site/public/docs/5.x/assets/examples/query-param.json
@@ -1,0 +1,28 @@
+{
+  "id": "74c6d0f4-49a5-49b9-ad54-93acbf815b43",
+  "name": "Query param example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "00c0b16e-50ff-4e05-9028-8a3318b11db0",
+      "elementFinder": "//input[@name=\"username\"]",
+      "name": "Fill from ?username=",
+      "value": "Query::username"
+    },
+    {
+      "id": "518dc17b-a2b1-4f63-9b80-d832939287e2",
+      "elementFinder": "#last-name",
+      "name": "Fill from ?name=",
+      "value": "Query::name"
+    },
+    {
+      "id": "c3fa90b8-4bc4-43fe-81b0-4828196d10a5",
+      "elementFinder": "#address",
+      "name": "Fill from ?city=",
+      "value": "Query::city"
+    }
+  ]
+}

--- a/site/public/docs/5.x/assets/examples/random-value.json
+++ b/site/public/docs/5.x/assets/examples/random-value.json
@@ -1,0 +1,28 @@
+{
+  "id": "33a3ff02-97b3-4fa0-8be4-01daac2ee49d",
+  "name": "Random value example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "3060ac19-ab9f-4eef-9a55-910d67b3892e",
+      "elementFinder": "#last-name",
+      "name": "Six random lowercase letters",
+      "value": "<random[a-z]{6}>"
+    },
+    {
+      "id": "6bb67c94-24dd-479e-b513-34fa36e20789",
+      "elementFinder": "#inputEmail",
+      "name": "Random local part",
+      "value": "<random[a-z]{5}>@example.com"
+    },
+    {
+      "id": "2be06468-e492-4b33-b70f-fb2b77a1dd98",
+      "elementFinder": "#inputPassword",
+      "name": "Random word characters",
+      "value": "<random[\\w]{10}>"
+    }
+  ]
+}

--- a/site/public/docs/5.x/assets/examples/repeat.json
+++ b/site/public/docs/5.x/assets/examples/repeat.json
@@ -1,0 +1,22 @@
+{
+  "id": "0dc78b37-f5e8-47ba-9239-670d7f471ceb",
+  "name": "Repeat placeholders example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "batch": {
+    "repeat": 2,
+    "repeatInterval": 2
+  },
+  "actions": [
+    {
+      "id": "678e015e-66dc-4bef-b6b3-20cc716fc982",
+      "elementFinder": "#last-name",
+      "name": "Both counters",
+      "value": "step <stepRepeat> of loop <loopRepeat>",
+      "repeat": 3,
+      "repeatInterval": 1
+    }
+  ]
+}

--- a/site/public/docs/5.x/assets/examples/select-option.json
+++ b/site/public/docs/5.x/assets/examples/select-option.json
@@ -1,0 +1,28 @@
+{
+  "id": "1ed4cd73-7554-4e03-97e8-ab9aa854fd5e",
+  "name": "Select Option example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "fc65a3e2-2553-439b-8be9-47b51e59ff12",
+      "elementFinder": "#product-size",
+      "name": "Select by visible text",
+      "value": "36"
+    },
+    {
+      "id": "a2f304cc-77ff-440e-a93c-e0415b4aa2c1",
+      "elementFinder": "#product-size",
+      "name": "Select by option value",
+      "value": "opt-38item-3"
+    },
+    {
+      "id": "0d3ffd44-ec7b-48be-bd2b-5d265614dd6d",
+      "elementFinder": "//select[@name=\"cars\"]",
+      "name": "Select by text in another dropdown",
+      "value": "Audi"
+    }
+  ]
+}

--- a/site/public/docs/5.x/assets/examples/session.json
+++ b/site/public/docs/5.x/assets/examples/session.json
@@ -1,0 +1,22 @@
+{
+  "id": "e70072f1-9eb3-4eb6-a4e5-ab9e18b3d2c9",
+  "name": "Session count example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "5f6a33c2-0863-4c00-a540-30a2f01f8ca5",
+      "elementFinder": "#last-name",
+      "name": "sessionCount increments per refresh",
+      "value": "visit-<sessionCount>"
+    },
+    {
+      "id": "8df2ffb3-42ff-4b44-a9f1-0ed9f08ef857",
+      "elementFinder": "#address",
+      "name": "Same value, inline",
+      "value": "session id <sessionCount>"
+    }
+  ]
+}

--- a/site/public/docs/5.x/assets/examples/state-guard.json
+++ b/site/public/docs/5.x/assets/examples/state-guard.json
@@ -1,0 +1,38 @@
+{
+  "id": "3a48d7d0-20d0-4c36-ae9c-ff8dd5348445",
+  "name": "State Guard example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "334ea165-ea86-4804-baae-ab03a41f318e",
+      "elementFinder": "#does-not-exist",
+      "name": "Step 1 - target missing on purpose",
+      "value": "never runs"
+    },
+    {
+      "id": "45b2c850-cca8-4aad-9e7d-e65a7021be4b",
+      "elementFinder": "#address",
+      "name": "Step 2 - gated on step 1 being DONE",
+      "value": "should be skipped",
+      "statement": {
+        "conditions": [
+          {
+            "id": "a8a62f19-4641-44e7-aa4e-5a63de13bafa",
+            "actionId": "334ea165-ea86-4804-baae-ab03a41f318e",
+            "status": "done"
+          }
+        ],
+        "option": "skip"
+      }
+    },
+    {
+      "id": "59f724c5-d64b-48c0-ae9e-7285af8aedcd",
+      "elementFinder": "#last-name",
+      "name": "Step 3 - unaffected",
+      "value": "step 3 still runs"
+    }
+  ]
+}

--- a/site/public/docs/5.x/assets/examples/step-value-basics.json
+++ b/site/public/docs/5.x/assets/examples/step-value-basics.json
@@ -1,0 +1,33 @@
+{
+  "id": "868241a0-ce45-4c76-9491-aee517a1eb1e",
+  "name": "Step Value basics",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "6c09ad87-0bec-4142-b247-33fbba24c70e",
+      "elementFinder": "#last-name",
+      "name": "Plain text fill",
+      "value": "filled by autofill"
+    },
+    {
+      "id": "afbbffec-bae1-4f8c-be82-dbc1a9b131b7",
+      "elementFinder": "#address",
+      "name": "Clear a field with ::empty",
+      "value": "::empty"
+    },
+    {
+      "id": "ea147a83-9f06-40b7-9c81-0bdf74861cfb",
+      "elementFinder": "#content-editable",
+      "name": "contentEditable element",
+      "value": "contentEditable filled"
+    },
+    {
+      "id": "c1d342fb-2e12-4bb3-8335-5259a5b2e3ab",
+      "elementFinder": "#click-events-test",
+      "name": "Default click (no value)"
+    }
+  ]
+}

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -18,9 +18,14 @@ const docsSchema = z.object({
     })
     .array()
     .optional(),
+  // Renders a card grid of links on the page. By default each card links to a sibling page
+  // in the same directory, derived from `title` — so `title: Element Finder` on a page in
+  // `step/` links to `step/element-finder`. Set `href` when the target lives elsewhere.
+  // A card whose target does not exist fails the build; see `DocsLayout.astro`.
   sections: z
     .object({
       description: z.string(),
+      href: z.string().optional(),
       title: z.string()
     })
     .array()

--- a/site/src/content/docs/settings/overview.mdx
+++ b/site/src/content/docs/settings/overview.mdx
@@ -12,7 +12,7 @@ sections:
     description: Configure how the extension retries failed steps or element lookups.
   - title: Show Notification
     description: Enable or disable notifications for important events and steps.
-  - title: Backup
+  - title: Cloud Backup
     description: Back up and restore your settings and automations for safety.
   - title: Migration Backup
     description: View, download, or restore local snapshots captured before schema migrations.

--- a/site/src/content/docs/step/columns-filter.mdx
+++ b/site/src/content/docs/step/columns-filter.mdx
@@ -8,15 +8,6 @@ tags: [step, action, columns, filter, visibility]
 aliases:
   - '/docs/4.x/action/columns-filter/'
   - '/docs/3.x/action/columns-filter/'
-sections:
-  - title: Name
-    description: Show or hide the step name column for easier identification.
-  - title: Delay
-    description: Toggle visibility of the delay column for steps.
-  - title: Repeat
-    description: Show or hide the repeat count column to control step loops.
-  - title: Interval
-    description: Toggle the interval column to manage delays between repeats.
 ---
 
 ## Show or hide columns in the Steps table
@@ -27,6 +18,13 @@ Notes:
 
 - By default, these optional columns are hidden to reduce clutter.
 - Values remain active even when a column is hidden. Reveal a column when you need to view or edit it.
+
+## Available columns
+
+- **Name** — show or hide the step name column for easier identification.
+- **Delay** — toggle visibility of the delay column for steps.
+- **Repeat** — show or hide the repeat count column to control step loops.
+- **Interval** — toggle the interval column to manage delays between repeats.
 
 <img
   class="d-block mb-4 img-fluid rounded-3 border"

--- a/site/src/content/docs/step/overview.mdx
+++ b/site/src/content/docs/step/overview.mdx
@@ -12,6 +12,8 @@ sections:
   - title: Element Finder
     description: 'Locate the target element on the page using flexible strategies.'
   - title: Value
+    # Lives in the sibling `step-value/` directory rather than under `step/`.
+    href: '/step-value/overview/'
     description: 'Define what the step does: click, fill, extract, or trigger commands.'
   - title: Page Guard
     description: 'Extend steps with pre-checks and advanced logic.'

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -2,6 +2,7 @@
 import type { MarkdownHeading } from 'astro'
 import type { CollectionEntry } from 'astro:content'
 import { getConfig } from '@libs/config'
+import { docsPages } from '@libs/content'
 import type { LayoutOverridesHTMLAttributes } from '@libs/layout'
 import { getSlug, processMarkdownToHtml } from '@libs/utils'
 import { getVersionedDocsPath } from '@libs/path'
@@ -21,6 +22,28 @@ const { frontmatter, headings, id } = Astro.props
 
 // Extract the directory/section from the ID (format: "directory/filename.mdx")
 const parentDirectory = id.includes('/') ? id.split('/')[0] : ''
+
+// Resolve the `sections` card grid to real links, and fail the build on a dead one.
+// By default a card links to a sibling page derived from its title, which silently 404s
+// when the title doesn't match a file on disk — see the note on `getSlug()` in
+// `src/libs/utils.ts`. `href` is the escape hatch for targets in another directory.
+const sectionLinks = (frontmatter.sections ?? []).map((section) => {
+  if (section.href) {
+    return { ...section, url: getVersionedDocsPath(section.href) }
+  }
+
+  const target = `${parentDirectory ? parentDirectory + '/' : ''}${getSlug(section.title)}`
+
+  if (!docsPages.some((page) => page.id === target)) {
+    throw new Error(
+      `The section '${section.title}' on page '${id}' links to '${target}', which does not exist. ` +
+        `Either rename the section title to match the target page, set an explicit 'href' on the ` +
+        `section, or remove it from 'sections' if it is not a link to another page.`
+    )
+  }
+
+  return { ...section, url: getVersionedDocsPath(`${target}/`) }
+})
 
 const bodyProps: LayoutOverridesHTMLAttributes<'body'> = {}
 
@@ -116,16 +139,11 @@ if (frontmatter.toc) {
 
       <div class="bd-content ps-lg-2">
         {
-          frontmatter.sections && (
+          sectionLinks.length > 0 && (
             <div class="row g-3">
-              {frontmatter.sections.map((section) => (
+              {sectionLinks.map((section) => (
                 <div class="col-md-6">
-                  <a
-                    class="d-block text-decoration-none"
-                    href={getVersionedDocsPath(
-                      `${parentDirectory ? parentDirectory + '/' : ''}${getSlug(section.title)}/`
-                    )}
-                  >
+                  <a class="d-block text-decoration-none" href={section.url}>
                     <strong class="d-block h5 mb-0">{section.title}</strong>
                     <span class="text-secondary">{section.description}</span>
                   </a>

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -20,7 +20,7 @@ interface Props {
 
 const { frontmatter, headings, id } = Astro.props
 
-// Extract the directory/section from the ID (format: "directory/filename.mdx")
+// Extract the directory/section from the ID (format: "directory/slug")
 const parentDirectory = id.includes('/') ? id.split('/')[0] : ''
 
 // Resolve the `sections` card grid to real links, and fail the build on a dead one.
@@ -29,6 +29,15 @@ const parentDirectory = id.includes('/') ? id.split('/')[0] : ''
 // `src/libs/utils.ts`. `href` is the escape hatch for targets in another directory.
 const sectionLinks = (frontmatter.sections ?? []).map((section) => {
   if (section.href) {
+    const hrefTarget = section.href.split('#')[0].replace(/^\/+|\/+$/g, '')
+
+    if (!docsPages.some((page) => page.id === hrefTarget)) {
+      throw new Error(
+        `The section '${section.title}' on page '${id}' links to '${hrefTarget}', which does not exist. ` +
+          `Fix the 'href' value or remove it from 'sections' if it is not a link to another page.`
+      )
+    }
+
     return { ...section, url: getVersionedDocsPath(section.href) }
   }
 

--- a/site/static/docs/[version]/assets/examples/copy-paste.json
+++ b/site/static/docs/[version]/assets/examples/copy-paste.json
@@ -1,0 +1,34 @@
+{
+  "id": "05e517f8-5ea9-4ad1-83f8-ce91e0945054",
+  "name": "Copy and Paste example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "fa69dacd-8377-4d08-b201-45225f0d9f8d",
+      "elementFinder": "#last-name",
+      "name": "Seed the source field",
+      "value": "Copy me 12345"
+    },
+    {
+      "id": "711febac-da1a-476a-82e1-186ea97ac83b",
+      "elementFinder": "#last-name",
+      "name": "Copy the field value",
+      "value": "Clipboard::copy::"
+    },
+    {
+      "id": "d855b8ab-e40b-454d-a76b-0e5333d7fbc8",
+      "elementFinder": "#address",
+      "name": "Paste it verbatim",
+      "value": "Clipboard::paste::"
+    },
+    {
+      "id": "c049624b-d370-4159-8b84-c0c14b33ba9b",
+      "elementFinder": "#inputEmail",
+      "name": "Paste transformed",
+      "value": "Clipboard::paste::toUpperCase()"
+    }
+  ]
+}

--- a/site/static/docs/[version]/assets/examples/element-finder.json
+++ b/site/static/docs/[version]/assets/examples/element-finder.json
@@ -1,0 +1,52 @@
+{
+  "id": "86132d8d-5e70-4038-b88a-2bc6618af436",
+  "name": "Element Finder example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "f2654a23-b4d5-4bc5-81da-1519d903f22e",
+      "elementFinder": "//input[@name=\"username\"]",
+      "name": "XPath by attribute",
+      "value": "xpath-attribute"
+    },
+    {
+      "id": "6fc067e2-eae6-4076-ba16-271d483e5444",
+      "elementFinder": "//input[contains(@placeholder,\"First name\")]",
+      "name": "XPath contains()",
+      "value": "xpath-contains"
+    },
+    {
+      "id": "9f4a60eb-ac4a-4518-a4fa-6b143da0a253",
+      "elementFinder": "#last-name",
+      "name": "ID with # prefix",
+      "value": "hash-id"
+    },
+    {
+      "id": "8c88d514-6b50-4a47-bb1b-4e3181b86058",
+      "elementFinder": "id::inputEmail",
+      "name": "ID with id:: prefix",
+      "value": "id-prefix@example.com"
+    },
+    {
+      "id": "091df324-d39a-42c3-8b12-22b9d74d4bd1",
+      "elementFinder": "Selector::#address",
+      "name": "CSS via Selector::",
+      "value": "css-selector"
+    },
+    {
+      "id": "0818f18b-0213-465a-a003-6003268d21c7",
+      "elementFinder": "Name::username",
+      "name": "By name attribute",
+      "value": "by-name"
+    },
+    {
+      "id": "90407f3c-7142-48f9-961d-11d482daa566",
+      "elementFinder": "#shadow-input",
+      "name": "Inside shadow DOM",
+      "value": "shadow-dom"
+    }
+  ]
+}

--- a/site/static/docs/[version]/assets/examples/events.json
+++ b/site/static/docs/[version]/assets/examples/events.json
@@ -1,0 +1,58 @@
+{
+  "id": "62f58dc6-7c10-455a-9588-7100fd758846",
+  "name": "Value commands showcase",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "2990b4c6-5b07-4596-8672-6fef76be6014",
+      "elementFinder": "#last-name",
+      "name": "Attr:: set an attribute",
+      "value": "Attr::set::data-example::hello"
+    },
+    {
+      "id": "bbe03a3a-0cb5-4cf3-954d-6031425ae0dd",
+      "elementFinder": "#address",
+      "name": "Class:: add a class",
+      "value": "Class::add::example-added"
+    },
+    {
+      "id": "5b13a73c-fd70-4c59-9301-47441aeb0e18",
+      "elementFinder": "#inputEmail",
+      "name": "Seed a value to transform",
+      "value": "cat@example.com"
+    },
+    {
+      "id": "52cad204-defa-46d0-ae5c-49dbcb23c26d",
+      "elementFinder": "#inputEmail",
+      "name": "Replace:: substring",
+      "value": "Replace::cat::dog"
+    },
+    {
+      "id": "d864d5fd-a87e-4431-8345-574dd35e3384",
+      "elementFinder": "#last-name",
+      "name": "Append:: to current value",
+      "value": "Append::-appended"
+    },
+    {
+      "id": "c3cc232f-4103-4bad-9dc4-f3c818f8f0f9",
+      "elementFinder": "#last-name",
+      "name": "Prepend:: to current value",
+      "value": "Prepend::pre-"
+    },
+    {
+      "id": "5211d5f8-73bb-4bdc-9644-8090e267c0d1",
+      "elementFinder": "#form-events-test",
+      "name": "FormEvents:: dispatch",
+      "value": "FormEvents::click"
+    },
+    {
+      "id": "c73ec4dc-ab54-4bab-8ea3-9db25a19c082",
+      "elementFinder": "#content-editable",
+      "name": "ScrollTo:: the page",
+      "value": "ScrollTo::Bottom"
+    }
+  ]
+}

--- a/site/static/docs/[version]/assets/examples/goto.json
+++ b/site/static/docs/[version]/assets/examples/goto.json
@@ -1,0 +1,34 @@
+{
+  "id": "95523be6-af71-475d-95fa-82bfb665bb77",
+  "name": "Goto example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "cd5d0cb2-3055-4fba-b470-a9acdce6589d",
+      "elementFinder": "#does-not-exist",
+      "name": "Step 1 - fails, jumps to step 3",
+      "value": "never runs",
+      "settings": {
+        "retry": 1,
+        "retryInterval": 1,
+        "retryOption": "goto",
+        "retryGoto": 2
+      }
+    },
+    {
+      "id": "f6a7d1a1-a083-4737-931c-445c73c70bb6",
+      "elementFinder": "#address",
+      "name": "Step 2 - jumped over",
+      "value": "skipped by the goto"
+    },
+    {
+      "id": "9103aa88-fd21-44ee-af35-74c8b3f17827",
+      "elementFinder": "#last-name",
+      "name": "Step 3 - the goto target",
+      "value": "jumped here from step 1"
+    }
+  ]
+}

--- a/site/static/docs/[version]/assets/examples/loop.json
+++ b/site/static/docs/[version]/assets/examples/loop.json
@@ -1,0 +1,24 @@
+{
+  "id": "44ce60aa-34ff-4251-bbef-fd1ac39b1d01",
+  "name": "Loop example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "batch": {
+    "repeat": 3,
+    "repeatInterval": 1
+  },
+  "actions": [
+    {
+      "id": "fdf5caeb-ee69-4f89-845d-06443e47f09e",
+      "elementFinder": "#last-name",
+      "value": "Loop run <loopRepeat>"
+    },
+    {
+      "id": "8444c59c-792e-43fa-aa9c-2f23c5c30ed9",
+      "elementFinder": "#inputEmail",
+      "value": "run-<loopRepeat>@example.com"
+    }
+  ]
+}

--- a/site/static/docs/[version]/assets/examples/page-guard.json
+++ b/site/static/docs/[version]/assets/examples/page-guard.json
@@ -1,0 +1,30 @@
+{
+  "id": "42a6de12-0d27-4727-aeb1-2a5c3d7d2299",
+  "name": "Page Guard example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "9fe3238f-9e9e-4ea8-83d1-2a251d852fd0",
+      "elementFinder": "#address",
+      "name": "Runs only if the guard matches",
+      "value": "Guard passed",
+      "addon": {
+        "elementFinder": "#last-name",
+        "value": "ready",
+        "condition": "Contains",
+        "recheck": 3,
+        "recheckInterval": 1,
+        "recheckOption": "skip"
+      }
+    },
+    {
+      "id": "a4e9cc3d-011a-4763-b38e-770f715ed4ca",
+      "elementFinder": "#last-name",
+      "name": "Sets the value the guard waits for",
+      "value": "ready"
+    }
+  ]
+}

--- a/site/static/docs/[version]/assets/examples/query-param.json
+++ b/site/static/docs/[version]/assets/examples/query-param.json
@@ -1,0 +1,28 @@
+{
+  "id": "74c6d0f4-49a5-49b9-ad54-93acbf815b43",
+  "name": "Query param example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "00c0b16e-50ff-4e05-9028-8a3318b11db0",
+      "elementFinder": "//input[@name=\"username\"]",
+      "name": "Fill from ?username=",
+      "value": "Query::username"
+    },
+    {
+      "id": "518dc17b-a2b1-4f63-9b80-d832939287e2",
+      "elementFinder": "#last-name",
+      "name": "Fill from ?name=",
+      "value": "Query::name"
+    },
+    {
+      "id": "c3fa90b8-4bc4-43fe-81b0-4828196d10a5",
+      "elementFinder": "#address",
+      "name": "Fill from ?city=",
+      "value": "Query::city"
+    }
+  ]
+}

--- a/site/static/docs/[version]/assets/examples/random-value.json
+++ b/site/static/docs/[version]/assets/examples/random-value.json
@@ -1,0 +1,28 @@
+{
+  "id": "33a3ff02-97b3-4fa0-8be4-01daac2ee49d",
+  "name": "Random value example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "3060ac19-ab9f-4eef-9a55-910d67b3892e",
+      "elementFinder": "#last-name",
+      "name": "Six random lowercase letters",
+      "value": "<random[a-z]{6}>"
+    },
+    {
+      "id": "6bb67c94-24dd-479e-b513-34fa36e20789",
+      "elementFinder": "#inputEmail",
+      "name": "Random local part",
+      "value": "<random[a-z]{5}>@example.com"
+    },
+    {
+      "id": "2be06468-e492-4b33-b70f-fb2b77a1dd98",
+      "elementFinder": "#inputPassword",
+      "name": "Random word characters",
+      "value": "<random[\\w]{10}>"
+    }
+  ]
+}

--- a/site/static/docs/[version]/assets/examples/repeat.json
+++ b/site/static/docs/[version]/assets/examples/repeat.json
@@ -1,0 +1,22 @@
+{
+  "id": "0dc78b37-f5e8-47ba-9239-670d7f471ceb",
+  "name": "Repeat placeholders example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "batch": {
+    "repeat": 2,
+    "repeatInterval": 2
+  },
+  "actions": [
+    {
+      "id": "678e015e-66dc-4bef-b6b3-20cc716fc982",
+      "elementFinder": "#last-name",
+      "name": "Both counters",
+      "value": "step <stepRepeat> of loop <loopRepeat>",
+      "repeat": 3,
+      "repeatInterval": 1
+    }
+  ]
+}

--- a/site/static/docs/[version]/assets/examples/select-option.json
+++ b/site/static/docs/[version]/assets/examples/select-option.json
@@ -1,0 +1,28 @@
+{
+  "id": "1ed4cd73-7554-4e03-97e8-ab9aa854fd5e",
+  "name": "Select Option example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "fc65a3e2-2553-439b-8be9-47b51e59ff12",
+      "elementFinder": "#product-size",
+      "name": "Select by visible text",
+      "value": "36"
+    },
+    {
+      "id": "a2f304cc-77ff-440e-a93c-e0415b4aa2c1",
+      "elementFinder": "#product-size",
+      "name": "Select by option value",
+      "value": "opt-38item-3"
+    },
+    {
+      "id": "0d3ffd44-ec7b-48be-bd2b-5d265614dd6d",
+      "elementFinder": "//select[@name=\"cars\"]",
+      "name": "Select by text in another dropdown",
+      "value": "Audi"
+    }
+  ]
+}

--- a/site/static/docs/[version]/assets/examples/session.json
+++ b/site/static/docs/[version]/assets/examples/session.json
@@ -1,0 +1,22 @@
+{
+  "id": "e70072f1-9eb3-4eb6-a4e5-ab9e18b3d2c9",
+  "name": "Session count example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "5f6a33c2-0863-4c00-a540-30a2f01f8ca5",
+      "elementFinder": "#last-name",
+      "name": "sessionCount increments per refresh",
+      "value": "visit-<sessionCount>"
+    },
+    {
+      "id": "8df2ffb3-42ff-4b44-a9f1-0ed9f08ef857",
+      "elementFinder": "#address",
+      "name": "Same value, inline",
+      "value": "session id <sessionCount>"
+    }
+  ]
+}

--- a/site/static/docs/[version]/assets/examples/state-guard.json
+++ b/site/static/docs/[version]/assets/examples/state-guard.json
@@ -1,0 +1,38 @@
+{
+  "id": "3a48d7d0-20d0-4c36-ae9c-ff8dd5348445",
+  "name": "State Guard example",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "334ea165-ea86-4804-baae-ab03a41f318e",
+      "elementFinder": "#does-not-exist",
+      "name": "Step 1 - target missing on purpose",
+      "value": "never runs"
+    },
+    {
+      "id": "45b2c850-cca8-4aad-9e7d-e65a7021be4b",
+      "elementFinder": "#address",
+      "name": "Step 2 - gated on step 1 being DONE",
+      "value": "should be skipped",
+      "statement": {
+        "conditions": [
+          {
+            "id": "a8a62f19-4641-44e7-aa4e-5a63de13bafa",
+            "actionId": "334ea165-ea86-4804-baae-ab03a41f318e",
+            "status": "done"
+          }
+        ],
+        "option": "skip"
+      }
+    },
+    {
+      "id": "59f724c5-d64b-48c0-ae9e-7285af8aedcd",
+      "elementFinder": "#last-name",
+      "name": "Step 3 - unaffected",
+      "value": "step 3 still runs"
+    }
+  ]
+}

--- a/site/static/docs/[version]/assets/examples/step-value-basics.json
+++ b/site/static/docs/[version]/assets/examples/step-value-basics.json
@@ -1,0 +1,33 @@
+{
+  "id": "868241a0-ce45-4c76-9491-aee517a1eb1e",
+  "name": "Step Value basics",
+  "url": "https://test.getautoclicker.com",
+  "enable": true,
+  "startType": "auto",
+  "loadType": "window",
+  "actions": [
+    {
+      "id": "6c09ad87-0bec-4142-b247-33fbba24c70e",
+      "elementFinder": "#last-name",
+      "name": "Plain text fill",
+      "value": "filled by autofill"
+    },
+    {
+      "id": "afbbffec-bae1-4f8c-be82-dbc1a9b131b7",
+      "elementFinder": "#address",
+      "name": "Clear a field with ::empty",
+      "value": "::empty"
+    },
+    {
+      "id": "ea147a83-9f06-40b7-9c81-0bdf74861cfb",
+      "elementFinder": "#content-editable",
+      "name": "contentEditable element",
+      "value": "contentEditable filled"
+    },
+    {
+      "id": "c1d342fb-2e12-4bb3-8335-5259a5b2e3ab",
+      "elementFinder": "#click-events-test",
+      "name": "Default click (no value)"
+    }
+  ]
+}


### PR DESCRIPTION
Started as a fix for 6 dead links, then the CI investigation surfaced 13 more with a shared root cause. Three related changes; the middle one is @dharmeshpatel's.

## 1. Six dead links from `sections` frontmatter (`8b8b3ba`)

`sections` renders a card grid in `DocsLayout`, deriving each href from the section **title** via `getSlug()`. When a title doesn't match a file on disk the card silently 404s — the fragility already flagged in the comment on `getSlug()` in [utils.ts](site/src/libs/utils.ts).

| Dead link | Source | Cause |
| --- | --- | --- |
| `/docs/5.x/settings/backup/` | `settings/overview` | title didn't match the file |
| `/docs/5.x/step/value/` | `step/overview` | target in another directory |
| `/docs/5.x/step/{name,delay,repeat,interval}/` | `step/columns-filter` | not pages at all |

Fixes: rename to `Cloud Backup`; add an optional **`href`** to the sections schema for cross-directory targets; move the columns-filter four into the body as a list, since they describe table columns rather than pages.

`DocsLayout` now **throws at build time** when a section resolves to a missing page, mirroring what `DocsSidebar` already does for `sidebar.yml`.

## 2. Crawler config comment (`496fe96`)

Removes the leading comment block, which the Algolia crawler dashboard rejected.

## 3. Thirteen missing example automations + the CI gate (`aecfa89`)

Every `<ExampleAutomation>` download was broken. The component and its 13 usages landed in `b93bd96` (#466) but **the JSON files were never created** — no object under `assets/examples` has ever existed in this repo's history. Because the anchors carry `download`, browsers saved the 404 HTML as `loop.json`, so it looked like it worked until you opened the file.

All 13 added, each demonstrating what its page documents, targeting elements verified present on test.getautoclicker.com:

```
element-finder   XPath, #id, id::, Selector::, Name::, shadow DOM
step-value-basics  plain fill, ::empty, contentEditable, default click
events           Attr:: Class:: Replace:: Append:: Prepend:: FormEvents:: ScrollTo::
copy-paste       Clipboard::copy / paste, incl. toUpperCase()
query-param      Query:: against the documented ?username&name&city
random-value     <random[a-z]{6}> patterns
session          <sessionCount> across refreshes
select-option    by visible text, by option value, second dropdown
repeat           <stepRepeat> and <loopRepeat> together
loop             batch repeat + interval with <loopRepeat>
page-guard       Contains condition with recheck
state-guard      step 2 skipped because step 1 was not DONE
goto             step 1 fails and jumps to step 3
```

**Validated against the real interfaces**, not by eye — `IAutomation`, `IStep`, `ILoop`, `IPageGuard`, `IStateGuard`, `IStepCondition`, `IStepSettings`, plus enum values (`EStartTypes`, `ELoadTypes`, `EErrorOptions`, `EStepStatus`, `EPageGuardConditions`) and `TBoundedValue`. All pass with no missing required fields and no unknown keys; state-guard `actionId`s are checked to reference a step in the same file. `migrateConfig()` is a no-op on them.

Files go in `site/static/docs/[version]/assets/` — the real source. `site/public` is generated from it and also tracked, matching how every existing asset is stored.

**The CI gate that let this ship** used `skip: '^http://localhost'` in both workflows. linkinator serves `_site` over localhost, so this skipped every *internal* link and checked only external ones — the opposite of the intent. `acf-blog` already uses the correct negated form. Now flipped, which is safe: a full crawl of the built site reports **zero** broken internal links.

## Verification

- `docs-build` 227 pages, `docs-vnu` exit 0
- All 13 example URLs resolve in the build; whole-site internal link crawl is clean
- Section guard confirmed to catch all six before the content fixes

## Worth a look before merge

- Examples use `startType: "auto"`, matching the docs wording ("open test.getautoclicker.com to watch it run") — but that means each fires on every visit to the test page once imported. Say if you'd prefer `"manual"`.
- I can't import these into the extension from here. The shapes are type-valid, but **one real import/run is worth doing** before this reaches users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)