### PR TITLE
docs: correct the .prettierignore note about site/static

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,12 +10,15 @@ CHANGELOG.md
 **/CHANGELOG.md
 **/dist/**
 
-# Vendored Bootstrap assets and examples, served as-is rather than authored here.
+# Generated, not authored: the `bootstrap()` integration's `copyStatic()` (see site/src/libs/astro.ts)
+# copies `site/static/**` here on every build with `[version]` renamed to the docs version, and
+# `copyBootstrap()` drops Bootstrap's `dist/` in from node_modules. Formatting it would be undone by
+# the next build.
 /site/public/
 
-# Hugo-era leftover: Astro's public dir is `site/public` (no `publicDir` override), nothing in the
-# config or source references `site/static`, and three of its files are byte-identical copies of
-# files under `site/public`. Formatting both copies is pure duplication.
+# The source `site/public` is copied from. The scripts under it are Bootstrap's docs scripts, kept as
+# upstream ships them; formatting them here and in the generated copy also counts double against
+# SonarCloud's duplication gate.
 /site/static/
 
 # Editor/agent config, not source.

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,7 +16,7 @@ CHANGELOG.md
 # the next build.
 /site/public/
 
-# The source `site/public` is copied from. The scripts under it are Bootstrap's docs scripts, kept as
+# The source `site/static` is copied from. The scripts under it are Bootstrap's docs scripts, kept as
 # upstream ships them; formatting them here and in the generated copy also counts double against
 # SonarCloud's duplication gate.
 /site/static/


### PR DESCRIPTION
Follow-up to #478, which landed a comment in `.prettierignore` stating that `site/static` is a Hugo-era leftover that nothing references. **That is wrong**, and the claim should not stay in the tree where it could justify deleting the directory.

## What is actually true

`site/static` is the source; `site/public` is generated from it.

The `bootstrap()` integration registered in `site/astro.config.ts` calls `copyStatic()` in `site/src/libs/astro.ts`, which copies `site/static/**` into `site/public/**` on every build, renaming the `[version]` directory to the docs version from `config.yml`. `copyBootstrap()` then adds Bootstrap's `dist/` from `node_modules`.

Checked rather than assumed:

- All **103** files under `site/static` have a counterpart in `site/public` under the `[version]` → `5.x` mapping — zero exceptions.
- `site/public` holds **46** further files with no `site/static` source: the Bootstrap `dist/` tree and a few root files.
- A build leaves `git status` clean for both trees, i.e. the committed generated copy already matches what the build produces.

So `site/public/docs/5.x/**` is generated output that happens to be committed, and `site/static/` is where the docs images, favicons, example JSON and Bootstrap docs scripts are authored. Deleting it would remove the source of every docs asset.

## What changes

Only the two comments in `.prettierignore`. Both directories stay ignored — but for the correct reasons: one is generated on every build, the other is upstream Bootstrap code that also counts double against SonarCloud's duplication gate when both copies are touched.

No behavior change; `prettier --check .` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)